### PR TITLE
Defaults Tests

### DIFF
--- a/test/extensions/clusters/aggregate/cluster_test.cc
+++ b/test/extensions/clusters/aggregate/cluster_test.cc
@@ -189,8 +189,11 @@ TEST_F(AggregateClusterTest, CircuitBreakerDefaultsTest) {
   Upstream::ResourceManager& resource_manager =
       cluster_->info()->resourceManager(Upstream::ResourcePriority::Default);
 
-  // take each of the: max_connections, max_pending_requests, max_requests, max_retries to their default limit
-  // then check that the circuit breaker prevents us from creating any more
+  // the default circuit breaker values are:
+  // max_connections : 1024
+  // max_pending_requests : 1024
+  // max_requests : 1024
+  // max_retries : 3
 
   EXPECT_EQ(1024U, resource_manager.connections().max());
   for (int i = 0; i < 1024; ++i) {

--- a/test/extensions/clusters/aggregate/cluster_test.cc
+++ b/test/extensions/clusters/aggregate/cluster_test.cc
@@ -182,6 +182,45 @@ public:
 )EOF";
 }; // namespace Aggregate
 
+TEST_F(AggregateClusterTest, CircuitBreakerDefaultsTest) {
+  initialize(default_yaml_config_);
+
+  // resource manager for the DEFAULT priority
+  Upstream::ResourceManager& resource_manager =
+      cluster_->info()->resourceManager(Upstream::ResourcePriority::Default);
+
+  // take each of the: max_connections, max_pending_requests, max_requests, max_retries to their default limit
+  // then check that the circuit breaker prevents us creating any more
+
+  EXPECT_EQ(1024U, resource_manager.connections().max());
+  for (int i = 0; i < 1024; ++i) {
+    resource_manager.connections().inc();
+  }
+  EXPECT_EQ(1024U, resource_manager.connections().count());
+  EXPECT_FALSE(resource_manager.connections().canCreate());
+
+  EXPECT_EQ(1024U, resource_manager.pendingRequests().max());
+  for (int i = 0; i < 1024; ++i) {
+    resource_manager.pendingRequests().inc();
+  }
+  EXPECT_EQ(1024U, resource_manager.pendingRequests().count());
+  EXPECT_FALSE(resource_manager.pendingRequests().canCreate());
+
+  EXPECT_EQ(1024U, resource_manager.requests().max());
+  for (int i = 0; i < 1024; ++i) {
+    resource_manager.requests().inc();
+  }
+  EXPECT_EQ(1024U, resource_manager.requests().count());
+  EXPECT_FALSE(resource_manager.requests().canCreate());
+
+  EXPECT_EQ(3U, resource_manager.retries().max());
+  for (int i = 0; i < 3; ++i) {
+    resource_manager.retries().inc();
+  }
+  EXPECT_EQ(3U, resource_manager.retries().count());
+  EXPECT_FALSE(resource_manager.retries().canCreate());
+}
+
 TEST_F(AggregateClusterTest, CircuitBreakerMaxConnectionsTest) {
   const std::string yaml_config = R"EOF(
     name: aggregate_cluster

--- a/test/extensions/clusters/aggregate/cluster_test.cc
+++ b/test/extensions/clusters/aggregate/cluster_test.cc
@@ -190,7 +190,7 @@ TEST_F(AggregateClusterTest, CircuitBreakerDefaultsTest) {
       cluster_->info()->resourceManager(Upstream::ResourcePriority::Default);
 
   // take each of the: max_connections, max_pending_requests, max_requests, max_retries to their default limit
-  // then check that the circuit breaker prevents us creating any more
+  // then check that the circuit breaker prevents us from creating any more
 
   EXPECT_EQ(1024U, resource_manager.connections().max());
   for (int i = 0; i < 1024; ++i) {


### PR DESCRIPTION
We need to test the circuit breaker defaults (when nothing is set in the yaml config) at the Aggregate Cluster level.

- `max_connections` : `1024`
- `max_pending_requests` : `1024`
- `max_requests` : `1024`
- `max_retries` : `3`

https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/cluster/v3/circuit_breaker.proto

This PR attempts to achieve that.

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

<!--
Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
-->